### PR TITLE
adding AlCaRecoTriggerBits key replacement feature

### DIFF
--- a/CondTools/HLT/python/AlCaRecoTriggerBitsRcdUpdate_cfi.py
+++ b/CondTools/HLT/python/AlCaRecoTriggerBitsRcdUpdate_cfi.py
@@ -22,6 +22,14 @@ AlCaRecoTriggerBitsRcdUpdate = cms.EDAnalyzer(
       cms.PSet(listName = cms.string('TkAlMinBias'),
                hltPaths = cms.vstring('path_1', 'path_3')
                )
-      )
+      ),
 
+    alcarecoToReplace = cms.VPSet(
+        cms.PSet(oldKey = cms.string('TkAlZMuMu'),
+                 newKey = cms.string('TkCalZMuMu')
+                 ),
+        cms.PSet(oldKey = cms.string('TkAlMinBias'),
+                 newKey = cms.string('TkCalMinBias')
+                 )
+        )
     )

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -40,6 +40,8 @@ private:
   typedef std::map<std::string, std::string> TriggerMap;
   AlCaRecoTriggerBits* createStartTriggerBits(bool startEmpty, const edm::EventSetup& evtSetup) const;
   bool removeKeysFromMap(const std::vector<std::string> &keys, TriggerMap &triggerMap) const;
+  bool replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace,
+			  TriggerMap &triggerMap) const;
   bool addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd,
 		       AlCaRecoTriggerBits &bits) const;
   /// Takes over memory uresponsibility for 'bitsToWrite'. 
@@ -51,6 +53,7 @@ private:
   const bool startEmpty_; 
   const std::vector<std::string> listNamesRemove_;
   const std::vector<edm::ParameterSet> triggerListsAdd_;
+  const std::vector<edm::ParameterSet> alcarecoReplace_;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -63,7 +66,8 @@ AlCaRecoTriggerBitsRcdUpdate::AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterS
     lastRunIOV_(cfg.getParameter<int>("lastRunIOV")),
     startEmpty_(cfg.getParameter<bool>("startEmpty")),
     listNamesRemove_(cfg.getParameter<std::vector<std::string> >("listNamesRemove")),
-    triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet> >("triggerListsAdd"))
+    triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet> >("triggerListsAdd")),
+    alcarecoReplace_(cfg.getParameter<std::vector<edm::ParameterSet> >("alcarecoToReplace"))
 {
 }
   
@@ -86,6 +90,9 @@ void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event& evt, const edm::Eve
 
   // now add new entries
   this->addTriggerLists(triggerListsAdd_, *bitsToWrite);
+
+  // now replace keys 
+  this->replaceKeysFromMap(alcarecoReplace_,bitsToWrite->m_alcarecoToTrig);
 
   // finally write to DB
   this->writeBitsToDB(bitsToWrite);
@@ -122,6 +129,34 @@ bool AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap(const std::vector<std::stri
       throw cms::Exception("BadConfig") << "[AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap] "
 					<< "Cannot remove key '" << *iKey << "' since not in "
 					<< "list - typo in configuration?\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////
+bool AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace,
+						      TriggerMap &triggerMap) const
+{
+
+  std::vector<std::pair<std::string,std::string> > keyPairs;
+
+  for(auto &iSet : alcarecoReplace ){
+    const std::string oldKey(iSet.getParameter<std::string>("oldKey"));
+    const std::string newKey(iSet.getParameter<std::string>("newKey"));
+    keyPairs.push_back(std::make_pair(oldKey,newKey));
+  }
+
+  for(auto& iKey : keyPairs){
+    if(triggerMap.find(iKey.first) != triggerMap.end() ){
+      std::string bitsToReplace = triggerMap[iKey.first];
+      triggerMap.erase(iKey.first);
+      triggerMap[iKey.second] = bitsToReplace;
+    } else { // not in list ==> misconfiguration!
+      edm::LogWarning("AlCaRecoTriggerBitsRcdUpdate") << "[AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap] "
+						      << "Cannot replace key '" << iKey.first << "with " << iKey.second << " since not in "
+						      << "list - typo in configuration?\n";
       return false;
     }
   }

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py
@@ -43,7 +43,7 @@ process.source = cms.Source("EmptySource",
 # With 'numberEventsInRun = 1' above,
 # this will check IOVs until run (!) number specified as 'input' here,
 # so take care to choose a one that is not too small...:
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(300000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(500000) )
 
 # Input for AlCaRecoTriggerBitsRcd,
 # either via GlobalTag

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py
@@ -78,9 +78,16 @@ process.AlCaRecoTriggerBitsRcdUpdate.startEmpty = False
 # Also if you want to replace settings for one 'key', you have to remove it first.
 #process.AlCaRecoTriggerBitsRcdUpdate.listNamesRemove = ["SiStripCalZeroBias"]
 # Here specifiy 'key' and corresponding paths for new entries or updated ones:
-process.AlCaRecoTriggerBitsRcdUpdate.triggerListsAdd = [
-    cms.PSet(listName = cms.string('AlCaEcalTrg'), # to be updated
-             hltPaths = cms.vstring('AlCa_EcalPhiSym*')
+# process.AlCaRecoTriggerBitsRcdUpdate.triggerListsAdd = [
+#     cms.PSet(listName = cms.string('AlCaEcalTrg'), # to be updated
+#              hltPaths = cms.vstring('AlCa_EcalPhiSym*')
+#              )
+#     ]
+
+process.AlCaRecoTriggerBitsRcdUpdate.triggerListsAdd = []
+process.AlCaRecoTriggerBitsRcdUpdate.alcarecoToReplace = [
+    cms.PSet(oldKey = cms.string('SiStripCalMinBiasAfterAbortGap'),
+             newKey = cms.string('SiStripCalMinBiasAAG')
              )
     ]
 


### PR DESCRIPTION
Greetings, 
this PR aims to deliver the possibility to automatically replace within a payload of type `AlCaRecoTriggerBits` a key `oldKey` with a new key `newKey` without changing the list of trigger paths attached to `oldKey`. 
A new method in `replaceKeysFromMap` has been introduced in the  `AlCaRecoTriggerBitsRcdUpdate` class, together with a new PSet from which one can specify the target and reference keys.
This update, in combination with the script 
https://github.com/cms-AlCaDB/AlCaTools/blob/master/CondTools/HLT/test/run_wf.py 
allows to quickly replace through many IOVs a key with another, keeping the pattern unchanged. 

attn: @tocheng @trtomei 