### PR TITLE
Add some useful scripts

### DIFF
--- a/scripts/checkoutIB.sh
+++ b/scripts/checkoutIB.sh
@@ -1,0 +1,28 @@
+export CMSSW_BRANCH=$1
+export MASTER_BRANCH=11_3_X
+if [[ ${CMSSW_BRANCH} = "10_6_X" ]]
+then
+    export SCRAM_ARCH=slc7_amd64_gcc700
+elif [[ ${CMSSW_BRANCH} = "11_1_X" ]]
+then
+    export SCRAM_ARCH=slc7_amd64_gcc820
+else
+    export SCRAM_ARCH=slc7_amd64_gcc900
+fi
+export CMSSW_VERSION=`scram list -c CMSSW | grep CMSSW_${CMSSW_BRANCH} | tail -1 | awk '{print $2}'`
+echo $SCRAM_ARCH
+echo $CMSSW_BRANCH
+echo $CMSSW_VERSION
+scramv1 project CMSSW $CMSSW_VERSION
+cd $CMSSW_VERSION/src
+eval `scramv1 runtime -sh`
+git cms-addpkg Configuration/AlCa
+
+export BRANCH_BASE=`pwd | awk -F '/' '{print $(NF-2)}'`
+if [[ ${CMSSW_BRANCH} = ${MASTER_BRANCH} ]]
+then
+    export BRANCH=alca-${BRANCH_BASE}
+else
+    export BRANCH=alca-${BRANCH_BASE}_${CMSSW_BRANCH}
+fi
+git checkout -b ${BRANCH}

--- a/scripts/diff_changes.py
+++ b/scripts/diff_changes.py
@@ -101,6 +101,9 @@ def main():
     diff_links_base = "https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/"
     diff_links = []
 
+    if new_gts[0] == '':
+        sys.exit('There is no difference between the local autoCond.py and the $CMSSW_RELEASE_BASE version, exiting!')
+
     for new_gt in new_gts:
         gt_base = re.sub('_v[0-9]*', '_', new_gt)
         if int(gt_base.split('_')[0][0:2]) < 111:

--- a/scripts/diff_changes.py
+++ b/scripts/diff_changes.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 """
-Perform difference between global tag listed
-in autoCond and the corresponding queue.
+Performs the difference between the GTs in your CMSSW release
+directory (including the modifications) with those in $CMSSW_RELEASE_BASE
+and prints out a list of URLs showing the set of GT diffs for use in a PR description.
 """
 import re
 import os
@@ -73,10 +74,28 @@ def global_tags(new_gt):
     # remove trailing newline as well
     return output[:-1].split('\n')
 
+def checkEnvironment():
+
+    currDir = os.getcwd()
+
+    if not "CMSSW" in currDir:
+        sys.exit('!! WARNING !! this script should be executed from the $CMSSW_BASE/src dirctory, exiting!')
+
+    if "CMSSW_BASE" not in os.environ:
+        sys.exit('!! WARNING !! This script should be executed after invoking the \'cmsenv\' command, exiting!')
+
+    cmsswBase = os.environ["CMSSW_BASE"]
+    if cmsswBase+'/src' != currDir:
+        sys.exit('!! WARNING !! This script should be executed in the same $CMSSW_BASE/src directory used to invoke the \'cmsenv\' command, exiting!')
+
+    if not os.path.isdir(currDir+'/Configuration/AlCa'):
+        sys.exit('!! WARNING !! Please checkout the Configuration/AlCa package before running this script, exiting!')
+
 def main():
     """Performs the difference between the GTs in your CMSSW release
     directory (including the modifications) with those in $CMSSW_RELEASE_BASE
     and prints out a list of URLs showing the set of GT diffs for use in a PR description."""
+    checkEnvironment()
     new_gts = global_tags(True)
     old_gts = global_tags(False)
     diff_links_base = "https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/"

--- a/scripts/diff_changes.py
+++ b/scripts/diff_changes.py
@@ -1,0 +1,112 @@
+#! /usr/bin/env python
+"""
+Perform difference between global tag listed
+in autoCond and the corresponding queue.
+"""
+import re
+import os
+import subprocess
+import sys
+
+descriptions = {
+    'mcRun1_design' : '**Run 1 design**',
+    'mcRun1_realistic' : '**Run 1 realistic**',
+    'mcRun1_HeavyIon' : '**Run 1 heavy ion**',
+    'mcRun1_pA' : '**Run 1 proton-heavy ion**',
+    'mcRun2_startup' : '**Run 2 startup**',
+    'mcRun2_asymptotic_l1stage1' : '**Run 2 (L1 trigger stage 1)**',
+    'mcRun2_design' : '**2016 design**',
+    'mcRun2_asymptotic_preVFP' : '**2016 realistic pre-VFP era**',
+    'mcRun2_asymptotic' : '**2016 realistic post-VFP era**',
+    'mcRun2cosmics_startup_deco' : '**2016 cosmics (startup conditions)**',
+    'mcRun2cosmics_asymptotic_deco' : '**2016 cosmics (asymptotic conditions)**',
+    'mcRun2_HeavyIon' : '**Run 2 heavy ion**',
+    'mcRun2_pA' : '**Run 2 proton-lead**',
+    'dataRun2' : '**Offline data**',
+    'dataRun2_2017_2018' : '**Offline data**',
+    'dataRun2_HEfail' : '**Offline data (HEM failure)**',
+    'dataRun2_relval' : '**Offline data relval**',
+    'dataRun2_PromptLike' : '**Prompt-like data**',
+    'dataRun2_PromptLike_HEfail' : '**Prompt-like data (HEM15/15 failure)**',
+    'dataRun2_PromptLike_HI' : '**Prompt-like HI data**',
+    'dataRun2_HLT_frozen' : '**Data (Frozen HLT GT)**',
+    'dataRun2_HLT_relval' : '**Run 2 HLT RelVals**',
+    'dataRun2_HLT_relval_HI' : '**Run 2 HI HLT RelVals**',
+    'dataRun2_HLTHI_frozen' : '**Run 2 HLT for HI (not 2018 HI)**',
+    'dataRun3_Express' : '**Run 3 data (express)**',
+    'dataRun3_Prompt' : '**Run 3 data (prompt)**',
+    'mc2017_design' : '**2017 design**',
+    'mc2017_design_IdealBS' : '**2017 design**',
+    'mc2017_realistic' : '**2017 realistic**',
+    'mc2017cosmics_realistic_deco' : '**2017 realistic cosmics (tracker deco mode)**',
+    'mc2017cosmics_realistic_peak' : '**2017 realistic cosmics (tracker peak mode)**',
+    'upgrade2018_design' : '**2018 design**',
+    'upgrade2018_realistic' : '**2018 realistic**',
+    'upgrade2018_realistic_RD' : '**2018 Run-dependent MC**',
+    'upgrade2018_realistic_HEfail' : '**2018 realistic (HEM15/16 failure)**',
+    'upgrade2018cosmics_realistic_deco' : '**2018 cosmics (tracker deco mode)**',
+    'upgrade2018cosmics_realistic_peak' : '**2018 cosmics (tracker peak mode)**',
+    'upgrade2018_realistic_HI' : '**2018 heavy ion**',
+    'upgrade2021_design' : '**2021 design**',
+    'upgrade2021_realistic' : '**2021 realistic**',
+    'upgrade2021cosmics_realistic_deco' : '**2021 cosmics**',
+    'mcRun3_2021_design' : '**2021 design**',
+    'mcRun3_2021cosmics_realistic_deco' : '**2021 cosmics**',
+    'mcRun3_2021_realistic' : '**2021 realistic**',
+    'mcRun3_2021_realistic_HI' : '**2021 heavy ion**',
+    'mcRun3_2023_realistic' : '**2023 realistic**',
+    'mcRun3_2024_realistic' : '**2024 realistic**',
+    'upgrade2023_realistic' : '**2023 realistic**',
+    'mcRun4_realistic' : '**Phase 2 realistic**'}
+
+def global_tags(new_gt):
+    """Get a list of global tags that have
+    changed since release."""
+    file = "Configuration/AlCa/python/autoCond.py"
+    manipulations = " | grep '>' | grep X | cut -d ':' -f 2 | sed 's/ //g' | cut -d ',' -f 1"
+    manipulations += " | sed \"s/'//g\""
+    if new_gt:
+        manipulations = manipulations.replace('>', '<')
+    cmd = "diff " + os.environ["CMSSW_BASE"] + "/src/" + file
+    cmd += " " + os.environ["CMSSW_RELEASE_BASE"] + "/src/" + file
+    output = os.popen(cmd + manipulations).read()
+    # remove trailing newline as well
+    return output[:-1].split('\n')
+
+def main():
+    """Perform difference between autoCond in release
+    and the corresponding queue."""
+    new_gts = global_tags(True)
+    old_gts = global_tags(False)
+    diff_links_base = "https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/"
+    diff_links = []
+
+    for new_gt in new_gts:
+        gt_base = re.sub('_v[0-9]*', '_', new_gt)
+        if int(gt_base.split('_')[0][0:2]) < 111:
+            gt_base = re.sub('_2017_2018_Candidate.*', '_', gt_base)
+        gt_base = re.sub('_Candidate.*', '_', gt_base)
+        gt_base = re.sub('_Queue', '_', gt_base)
+        old_gt = ''
+        for gt in old_gts:
+            gt_stripped = re.sub('_v[0-9]*', '_', gt)
+            gt_stripped = re.sub('_Candidate.*', '_', gt_stripped)
+            if gt_base == gt_stripped:
+                old_gt = gt
+                break
+        cmd = 'conddb diff ' + old_gt + ' ' + new_gt
+        diff_link = diff_links_base + old_gt + '/' + new_gt
+        if diff_link not in diff_links:
+            diff_links.append(diff_link)
+        print(cmd)
+        os.system(cmd)
+
+    for diff_link in diff_links:
+        new_gt = diff_link.split('/')[-1][5:]
+        new_gt_base = re.sub('_v[0-9]*', '', new_gt)
+        new_gt_base = re.sub('_Candidate.*', '', new_gt_base)
+        print(descriptions[new_gt_base])
+        print(diff_link + '\n')
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diff_changes.py
+++ b/scripts/diff_changes.py
@@ -74,8 +74,9 @@ def global_tags(new_gt):
     return output[:-1].split('\n')
 
 def main():
-    """Perform difference between autoCond in release
-    and the corresponding queue."""
+    """Performs the difference between the GTs in your CMSSW release
+    directory (including the modifications) with those in $CMSSW_RELEASE_BASE
+    and prints out a list of URLs showing the set of GT diffs for use in a PR description."""
     new_gts = global_tags(True)
     old_gts = global_tags(False)
     diff_links_base = "https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/"

--- a/scripts/diff_queues.py
+++ b/scripts/diff_queues.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+"""
+Perform difference between global tag listed
+in autoCond and the corresponding queue.
+"""
+import re
+import os
+
+from Configuration.AlCa.autoCond import autoCond
+
+def global_tags():
+    """Get a list of global tags from autoCond"""
+    global_tag_list = []
+    values = autoCond.values()
+    for global_tag in values:
+        if isinstance(global_tag, basestring) and global_tag not in global_tag_list:
+            global_tag_list.append(global_tag)
+    return global_tag_list
+
+def main():
+    """Perform difference between autoCond in release
+    and the corresponding queue."""
+    for global_tag in global_tags():
+        queue = re.sub('_v[0-9]*', '_Queue', global_tag)
+        queue = re.sub('_Candidate.*', '_Queue', queue)
+
+        # ignore frozen global tags
+        if '101X' in global_tag or '103X' in global_tag:
+            continue
+
+        # the dataRun2 global tag is currently
+        # taken from the 106X_dataRun2_2017_2018_Queue
+        if 'dataRun2_v' in global_tag and '105X' not in global_tag and '111X' not in global_tag and '112X' not in global_tag and '113X' not in global_tag:
+            queue = queue.replace('Queue', '2017_2018_Queue')
+
+        # this global tag uses a different naming convention
+        # for no particular reason
+        if 'IdealBS' in global_tag:
+            queue = queue.replace('_IdealBS', '')
+
+        # the 'dataRun2_HLT_relval_HI_v' GT is created from
+        # the 'dataRun2_HLT_relval' queue
+        if 'HLT_relval_HI' in global_tag:
+            queue = queue.replace('HI_', '')
+
+        # Diff command
+        cmd = 'conddb diff ' + global_tag + ' ' + queue
+        os.system(cmd)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diff_queues.py
+++ b/scripts/diff_queues.py
@@ -5,11 +5,11 @@ in autoCond and the corresponding queue.
 """
 import re
 import os
-
-from Configuration.AlCa.autoCond import autoCond
+import sys
 
 def global_tags():
     """Get a list of global tags from autoCond"""
+    from Configuration.AlCa.autoCond import autoCond
     global_tag_list = []
     values = autoCond.values()
     for global_tag in values:
@@ -17,9 +17,27 @@ def global_tags():
             global_tag_list.append(global_tag)
     return global_tag_list
 
+def checkEnvironment():
+
+    currDir = os.getcwd()
+
+    if not "CMSSW" in currDir:
+        sys.exit('!! WARNING !! this script should be executed from the $CMSSW_BASE/src dirctory, exiting!')
+
+    if "CMSSW_BASE" not in os.environ:
+        sys.exit('!! WARNING !! This script should be executed after invoking the \'cmsenv\' command, exiting!')
+
+    cmsswBase = os.environ["CMSSW_BASE"]
+    if cmsswBase+'/src' != currDir:
+        sys.exit('!! WARNING !! This script should be executed in the same $CMSSW_BASE/src directory used to invoke the \'cmsenv\' command, exiting!')
+
+    if not os.path.isdir(currDir+'/Configuration/AlCa'):
+        sys.exit('!! WARNING !! Please checkout the Configuration/AlCa package before running this script, exiting!')
+
 def main():
     """Perform difference between autoCond in release
     and the corresponding queue."""
+    checkEnvironment()
     for global_tag in global_tags():
         queue = re.sub('_v[0-9]*', '_Queue', global_tag)
         queue = re.sub('_Candidate.*', '_Queue', queue)


### PR DESCRIPTION
Adding few useful scripts to help creating and managing the PRs that update the autoCond.py script.
The scripts were originally written by @christopheralanwest and slightly updated to take into account the latest changes in the GTs and queues.

**checkoutIB.sh**
Downloads the latest available IB in a release cycle, invoked by:
`scripts/checkoutIB.sh [RELEASE CYCLE]`
for example: _scripts/checkoutIB.sh 11_3_X_

**diff_queues.py**
Performs the difference between the global tags listed in autoCond and the corresponding queues and prints to screen the differences. Invoked by:
`python scripts/diff_queues.py`

**diff_changes.py**
Performs the difference between the GTs in your CMSSW release directory (including the modifications) with those in $CMSSW_RELEASE_BASE and prints out a list of URLs showing the set of GT diffs for use in a PR description.
Invoked by:
`python scripts/diff_changes.py`


