### PR TITLE
ValidateHLTMenu compatibility update with CMSSW_12_3_X_2022-02-07-1100

### DIFF
--- a/ValidateHLTMenu/AlCaRecoHLTpaths8e29_1e31_v7_hlt_BitsRcdRead_FromTag_cfg.py
+++ b/ValidateHLTMenu/AlCaRecoHLTpaths8e29_1e31_v7_hlt_BitsRcdRead_FromTag_cfg.py
@@ -11,7 +11,8 @@ process = cms.Process("READ")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 # the module writing to DB
-process.load("CondTools.HLT.AlCaRecoTriggerBitsRcdRead_cfi")
+from CondTools.HLT.alCaRecoTriggerBitsRcdRead_cfi import alCaRecoTriggerBitsRcdRead as _alCaRecoTriggerBitsRcdRead
+process.AlCaRecoTriggerBitsRcdRead = _alCaRecoTriggerBitsRcdRead.clone()
 
 # 'twiki' is default - others are text, python (future: html?)
 #process.AlCaRecoTriggerBitsRcdRead.outputType = 'twiki'

--- a/ValidateHLTMenu/AlCaRecoTriggerBitsRcdRead_FromTag_cfg.py
+++ b/ValidateHLTMenu/AlCaRecoTriggerBitsRcdRead_FromTag_cfg.py
@@ -11,7 +11,8 @@ process = cms.Process("READ")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 # the module writing to DB
-process.load("CondTools.HLT.AlCaRecoTriggerBitsRcdRead_cfi")
+from CondTools.HLT.alCaRecoTriggerBitsRcdRead_cfi import alCaRecoTriggerBitsRcdRead as _alCaRecoTriggerBitsRcdRead
+process.AlCaRecoTriggerBitsRcdRead = _alCaRecoTriggerBitsRcdRead.clone()
 
 # 'twiki' is default - others are text, python (future: html?)
 #process.AlCaRecoTriggerBitsRcdRead.outputType = 'twiki'


### PR DESCRIPTION
* Update CondTools.HLT.AlCaRecoTriggerBitsRcdRead_cfi import in `AlcaRecoTriggerBitsRcdRead_FromTag_cfg.py` CMSSW template configuration file according to latest CondTools/HLT modernization (check [remove CondTools/HLT/python/ directory and use cfi from fillDescriptions](https://github.com/cms-sw/cmssw/commit/48487d6a9628c91a602e882b0217d7645b3622a1)).