### PR TITLE
minor improvement to `getAlCaCondInGT`: escape wikiwords in output

### DIFF
--- a/ConditionsConsumed/getAlCaCondInGT.py
+++ b/ConditionsConsumed/getAlCaCondInGT.py
@@ -29,8 +29,13 @@ def checkTagInFile(tag, logFile):
     else:
         return ""
 
+def escape_wikiwords(text):
+    # Use a regular expression to find words starting with a capital letter
+    return re.sub(r'\b([A-Z][a-zA-Z0-9]*)', r'!\1', text)
+
 def getOneRow(tag, logFiles):
-    rowName = "|" +tag.strip()
+    escaped_tag = escape_wikiwords(tag.strip())
+    rowName = "|" + escaped_tag
     for file_ in logFiles:
         checkTagInFile_ = checkTagInFile(tag, file_)
         rowName = rowName + " | " + checkTagInFile_


### PR DESCRIPTION
To avoid getting links to not-existing wikiwords when pasting to twiki. 
Ex.:

![Screenshot from 2024-11-20 23-10-00](https://github.com/user-attachments/assets/c018f7e6-ec96-4d2f-84bc-d064829f3429)

becomes

![Screenshot from 2024-11-20 23-10-16](https://github.com/user-attachments/assets/221aa015-27a2-434a-b111-d5895a5dbc58)
